### PR TITLE
data_type not handled by get_replicates_exhaustive

### DIFF
--- a/pysrc/rep_data.py
+++ b/pysrc/rep_data.py
@@ -311,7 +311,7 @@ def get_replicates_exhaustive(n_completed, results_queue, leafsets,
             "temp_inseqs.{}".format(rep["unique_label"]))
         # write file for successful rep
         if rep['paup'] is True:
-            write_paup(rep["aln_fname"], rep["seqs"])
+            write_paup(rep["aln_fname"], rep["seqs"], datatype=rep["data_type"])
         else:
             if params["low_mem"] is True:
                 # print(rep['seqs'], rep['seq_names'])


### PR DESCRIPTION
`get_replicates_exhaustive` was not handling data_type correctly when PAUP mode was used. This would cause PAUP* to generate an error if given a datatype other than the default 'nuc' (which is passed to PAUP* in the nexus file as 'dna'). PAUP* would then hang waiting for further input.